### PR TITLE
Adding 'Planned Sprint bars' to chart 

### DIFF
--- a/src/burnify.css
+++ b/src/burnify.css
@@ -39,6 +39,18 @@
     cursor: pointer;
 }
 
+.burnify .barPlanned {
+    fill: oldlace;
+}
+
+.burnify .barPlanned:hover {
+    fill: ivory;
+    stroke-width: 1px;
+    stroke-dasharray: 4, 4;
+    stroke: yellow;
+    cursor: pointer;
+}
+
 .burnify .line {
     stroke: #1d7fb3;
     stroke-width: 2px;

--- a/src/burnify.js
+++ b/src/burnify.js
@@ -88,8 +88,8 @@ Burnify.prototype.burnify = function(meta) {
             var y2 = createY2();
 
             renderScopeArea(x, y0);
-            renderSprintBars(x, y1, 'planned', 'barPlanned', meta.onPlannedSprintBarClick);
-            renderSprintBars(x, y2, 'done', 'bar', meta.onDoneSprintBarClick);
+            renderSprintPlannedBars(x, y1);
+            renderSprintDoneBars(x, y2);
             renderProjectLimit(x, y0);
             renderProjectMVP(x, y0);
             renderProductBurnLines(x, y0);

--- a/test/products.html
+++ b/test/products.html
@@ -13,15 +13,15 @@
     <link href="https://cdn.rawgit.com/feroult/burnify/burnify-0.3/src/burnify.css" rel="stylesheet" type="text/css">
     <script src="https://cdn.rawgit.com/feroult/burnify/burnify-0.3/src/burnify.js"></script>
 -->
-    
+
     <link href="../src/burnify.css" rel="stylesheet" type="text/css">
     <script src="../src/burnify.js"></script>
-    
+
     <style type="text/css">
         div.outter {
             width: 100%;
         }
-        
+
         div.inner {
             display: inline;
         }
@@ -35,6 +35,8 @@
         <div id="product2" class="inner"></div>
         <div id="product3" class="inner"></div>
         <div id="product4" class="inner"></div>
+
+        <div id="product5" class="inner"></div>
     </div>
 
     <script>
@@ -47,106 +49,65 @@
     	        "lastSprint": 13,
         	    "mvpSprint": 10,
             	"sprints": [
-					{
-                    	"planned": 10,
-	                    "done": 10
-    	    	    }, {
-        	            "planned": 12,
-            	        "done": 10
-		            }, {
-    	                "planned": 10,
-        	            "done": 10
-    	        	}, {
-                	    "planned": 10,
-	                    "done": 6,
-    	                "added": 52
-        		    }, {
-            	        "planned": 14,
-                	    "done": 8,
-                    	"added": 12
-	        	    }, {
-    	                "planned": 14,
-        	            "done": 8,
-            	        "added": 2,
-                	    "removed": 20
-	            	}, {
-    	                "planned": 12,
-        	            "done": 4
-	            	}, {
-                	    "planned": 10,
-	                    "done": 6,
-    	                "added": 2
-    	    	    }
+					{ "planned": 10, "done": 10 },
+					{ "planned": 12, "done": 10 },
+					{ "planned": 10, "done": 10 },
+					{ "planned": 10, "done": 6, "added": 52 },
+					{ "planned": 14, "done": 8, "added": 12 },
+					{ "planned": 14, "done": 8, "added": 2, "removed": 20 },
+					{ "planned": 12, "done": 4, },
+					{ "planned": 10, "done": 6, "added": 2 }
         	    ]
-			}, {
+		    }, {
 		        "name": "Burnify 2",
 		        "points": 220,
 		        "lastSprint": 10,
 		        "mvpSprint": 8,
-		        "sprints": [{
-		                "done": 18
-		        }, {
-		                "done": 24
-		        }, {
-		                "done": 16
-		        }, {
-		                "done": 22
-		        }, {
-		                "done": 8,
-		                "added": 32
-		        }, {
-		                "done": 20,
-		                "removed": 20
-		        }, {
-		                "done": 30,
-		                "added": 2
-		        }
-		    ]
-		}, {
+		        "sprints": [
+		            { "done": 18 },
+		            { "done": 24 },
+		            { "done": 16 },
+		            { "done": 22 },
+		            { "done": 8, "added": 32 },
+		            { "done": 20, "removed": 20 },
+		            { "done": 30, "added": 2 }
+		        ]
+    		}, {
 		        "name": "Burnify 3",
 		        "points": 120,
 		        "lastSprint": 10,
 		        "mvpSprint": 10,
-		        "sprints": [{
-		                "done": 10
-		        }, {
-		                "done": 10
-		        }, {
-		                "done": 10
-		        }
-		    ]
-		}, {
+		        "sprints": [
+		            { "done": 10 },
+		            { "done": 10 },
+		            { "done": 10 }
+		        ]
+		    }, {
 		        "name": "Burnify 4",
 		        "points": 200,
 		        "lastSprint": 10,
 		        "mvpSprint": 8,
-		        "sprints": [{
-		                "done": 20
-		        }, {
-		                "done": 20
-		        }, {
-		                "done": 20
-		        }
-		    ]
-		}
+		        "sprints": [
+		            { "done": 20 },
+		            { "done": 20 },
+		            { "done": 20 },
+		            { "done": 20 },
+		            { "planned": 10, "done": 10, "removed": 10 },
+		            { "planned": 20 },
+		            { "planned": 20 },
+		            { "planned": 20 },
+		            { "planned": 20 },
+		            { "planned": 20 }
+		        ]
+		    }
+
         ];
         	
-        b1 = new Burnify("#product1", products[0], 450, 250);
-        b1.onSprintBarClick = function(sprintNumber, sprint) { alert('Sprint ' + sprintNumber + ' (done: '+ sprint.done + ')'); };
-        b1.onFullScopeAreaClick = function(p) { alert('Project ' + p.name + ' full scope area!'); };
-        b1.onDoneScopeAreaClick = function(p) { alert('Project ' + p.name + ' done scope area!'); };
-        b1.onOutScopeAreaClick = function(p) { alert('Project ' + p.name + ' out scope area!'); };
-        b1.draw();
-
+        //$.getJSON('products.json', function (products) {
+        new Burnify("#product1", products[0], 450, 250).draw();
         new Burnify("#product2", products[1], 450, 250).draw();
         new Burnify("#product3", products[2], 450, 250).draw();
         new Burnify("#product4", products[3], 450, 250).draw();
-        
-        //$.getJSON('products.json', function (products) {
-        //	  new Burnify("#product1", products[0], 450, 250).draw();
-        //    new Burnify("#product2", products[1], 450, 250).draw();
-        //    new Burnify("#product3", products[2], 450, 250).draw();
-        //    new Burnify("#product4", products[3], 450, 250).draw();
         //});
     </script>
 


### PR DESCRIPTION
- Add 'planned' point to sprint representation
- Draw new overlapping bars representing planned points for sprint (in contrast to DONE points)
- Enhanced resilience for non-present data (mainly sprint points)
- Changed the burndown line for considering sprint 'planned' points instead of 'done' points if there aren't any done points yet.
